### PR TITLE
Update MockK test dependency from version 1.12.4 to 1.13.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <kotlin-logging-jvm.version>3.0.2</kotlin-logging-jvm.version>
         <quicktheories.version>0.26</quicktheories.version>
         <jackson-datatype.version>2.15.1</jackson-datatype.version>
-        <mockk.version>1.12.4</mockk.version>
+        <mockk.version>1.13.8</mockk.version>
 
         <!-- Other properties -->
         <start.class>fi.hsl.jore4.timetables.TimetablesApiApplicationKt</start.class>
@@ -563,7 +563,7 @@
 
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
+            <artifactId>mockk-jvm</artifactId>
             <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Starting with version 1.13.0, MockK supports Kotlin 1.4 and above, and we already use Kotlin 1.8 (through Spring Boot 3.x).

In `jore4-hastus` repository this already caused an error during GitHub runner execution while building Docker image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-timetables-api/10)
<!-- Reviewable:end -->
