### PR TITLE
Improve REST API tests

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/timetables/api/TimetablesController.kt
+++ b/src/main/kotlin/fi/hsl/jore4/timetables/api/TimetablesController.kt
@@ -118,29 +118,31 @@ class TimetablesController(
     @ExceptionHandler(RuntimeException::class)
     fun handleRuntimeException(ex: RuntimeException): ResponseEntity<HasuraErrorResponse> {
         val hasuraExtensions: HasuraErrorExtensions = when (ex) {
-            is InvalidTargetPriorityException -> {
-                InvalidTargetPriorityExtensions(HttpStatus.BAD_REQUEST, ex.targetPriority)
-            }
+            is InvalidTargetPriorityException -> InvalidTargetPriorityExtensions(
+                HttpStatus.BAD_REQUEST,
+                ex.targetPriority
+            )
 
-            is StagingVehicleScheduleFrameNotFoundException -> {
-                StagingVehicleScheduleFrameNotFoundExtensions(HttpStatus.NOT_FOUND, ex.stagingVehicleScheduleFrameId)
-            }
+            is StagingVehicleScheduleFrameNotFoundException -> StagingVehicleScheduleFrameNotFoundExtensions(
+                HttpStatus.NOT_FOUND,
+                ex.stagingVehicleScheduleFrameId
+            )
 
-            is TargetFrameNotFoundException -> {
-                TargetVehicleScheduleFrameNotFoundExtensions(HttpStatus.NOT_FOUND, ex.stagingVehicleScheduleFrameId)
-            }
+            is TargetFrameNotFoundException -> TargetVehicleScheduleFrameNotFoundExtensions(
+                HttpStatus.NOT_FOUND,
+                ex.stagingVehicleScheduleFrameId
+            )
 
-            is MultipleTargetFramesFoundException -> {
-                MultipleTargetFramesFoundExtensions(
-                    HttpStatus.CONFLICT,
-                    ex.stagingVehicleScheduleFrameId,
-                    ex.targetVehicleScheduleFrameIds
-                )
-            }
+            is MultipleTargetFramesFoundException -> MultipleTargetFramesFoundExtensions(
+                HttpStatus.CONFLICT,
+                ex.stagingVehicleScheduleFrameId,
+                ex.targetVehicleScheduleFrameIds
+            )
 
-            is TargetPriorityParsingException -> {
-                TargetPriorityParsingExtensions(HttpStatus.BAD_REQUEST, ex.targetPriority)
-            }
+            is TargetPriorityParsingException -> TargetPriorityParsingExtensions(
+                HttpStatus.BAD_REQUEST,
+                ex.targetPriority
+            )
 
             else -> {
                 LOGGER.error { "Exception during request:$ex" }

--- a/src/main/kotlin/fi/hsl/jore4/timetables/api/TimetablesController.kt
+++ b/src/main/kotlin/fi/hsl/jore4/timetables/api/TimetablesController.kt
@@ -118,31 +118,15 @@ class TimetablesController(
     @ExceptionHandler(RuntimeException::class)
     fun handleRuntimeException(ex: RuntimeException): ResponseEntity<HasuraErrorResponse> {
         val hasuraExtensions: HasuraErrorExtensions = when (ex) {
-            is InvalidTargetPriorityException -> InvalidTargetPriorityExtensions(
-                HttpStatus.BAD_REQUEST,
-                ex.targetPriority
-            )
+            is InvalidTargetPriorityException -> InvalidTargetPriorityExtensions.from(ex)
 
-            is StagingVehicleScheduleFrameNotFoundException -> StagingVehicleScheduleFrameNotFoundExtensions(
-                HttpStatus.NOT_FOUND,
-                ex.stagingVehicleScheduleFrameId
-            )
+            is StagingVehicleScheduleFrameNotFoundException -> StagingVehicleScheduleFrameNotFoundExtensions.from(ex)
 
-            is TargetFrameNotFoundException -> TargetVehicleScheduleFrameNotFoundExtensions(
-                HttpStatus.NOT_FOUND,
-                ex.stagingVehicleScheduleFrameId
-            )
+            is TargetFrameNotFoundException -> TargetVehicleScheduleFrameNotFoundExtensions.from(ex)
 
-            is MultipleTargetFramesFoundException -> MultipleTargetFramesFoundExtensions(
-                HttpStatus.CONFLICT,
-                ex.stagingVehicleScheduleFrameId,
-                ex.targetVehicleScheduleFrameIds
-            )
+            is MultipleTargetFramesFoundException -> MultipleTargetFramesFoundExtensions.from(ex)
 
-            is TargetPriorityParsingException -> TargetPriorityParsingExtensions(
-                HttpStatus.BAD_REQUEST,
-                ex.targetPriority
-            )
+            is TargetPriorityParsingException -> TargetPriorityParsingExtensions.from(ex)
 
             else -> {
                 LOGGER.error { "Exception during request:$ex" }

--- a/src/main/kotlin/fi/hsl/jore4/timetables/api/util/HasuraErrorExtensions.kt
+++ b/src/main/kotlin/fi/hsl/jore4/timetables/api/util/HasuraErrorExtensions.kt
@@ -1,6 +1,11 @@
 package fi.hsl.jore4.timetables.api.util
 
+import fi.hsl.jore4.timetables.api.TimetablesController.TargetPriorityParsingException
 import fi.hsl.jore4.timetables.enumerated.TimetablesPriority
+import fi.hsl.jore4.timetables.service.InvalidTargetPriorityException
+import fi.hsl.jore4.timetables.service.MultipleTargetFramesFoundException
+import fi.hsl.jore4.timetables.service.StagingVehicleScheduleFrameNotFoundException
+import fi.hsl.jore4.timetables.service.TargetFrameNotFoundException
 import org.springframework.http.HttpStatus
 import java.util.UUID
 
@@ -20,7 +25,12 @@ data class InvalidTargetPriorityExtensions(
     val targetPriority: TimetablesPriority
 ) : HasuraErrorExtensions {
 
-    constructor(httpStatus: HttpStatus, targetPriority: TimetablesPriority) : this(httpStatus.value(), targetPriority)
+    companion object {
+        fun from(ex: InvalidTargetPriorityException) = InvalidTargetPriorityExtensions(
+            HttpStatus.BAD_REQUEST.value(),
+            ex.targetPriority
+        )
+    }
 }
 
 data class StagingVehicleScheduleFrameNotFoundExtensions(
@@ -28,10 +38,12 @@ data class StagingVehicleScheduleFrameNotFoundExtensions(
     val stagingVehicleScheduleFrameId: UUID
 ) : HasuraErrorExtensions {
 
-    constructor(httpStatus: HttpStatus, stagingVehicleScheduleFrameId: UUID) : this(
-        httpStatus.value(),
-        stagingVehicleScheduleFrameId
-    )
+    companion object {
+        fun from(ex: StagingVehicleScheduleFrameNotFoundException) = StagingVehicleScheduleFrameNotFoundExtensions(
+            HttpStatus.NOT_FOUND.value(),
+            ex.stagingVehicleScheduleFrameId
+        )
+    }
 }
 
 data class TargetVehicleScheduleFrameNotFoundExtensions(
@@ -39,10 +51,12 @@ data class TargetVehicleScheduleFrameNotFoundExtensions(
     val stagingVehicleScheduleFrameId: UUID
 ) : HasuraErrorExtensions {
 
-    constructor(httpStatus: HttpStatus, stagingVehicleScheduleFrameId: UUID) : this(
-        httpStatus.value(),
-        stagingVehicleScheduleFrameId
-    )
+    companion object {
+        fun from(ex: TargetFrameNotFoundException) = TargetVehicleScheduleFrameNotFoundExtensions(
+            HttpStatus.NOT_FOUND.value(),
+            ex.stagingVehicleScheduleFrameId
+        )
+    }
 }
 
 data class MultipleTargetFramesFoundExtensions(
@@ -51,15 +65,13 @@ data class MultipleTargetFramesFoundExtensions(
     val targetVehicleScheduleFrameIds: List<UUID>
 ) : HasuraErrorExtensions {
 
-    constructor(
-        httpStatus: HttpStatus,
-        stagingVehicleScheduleFrameId: UUID,
-        targetVehicleScheduleFrameIds: List<UUID>
-    ) : this(
-        httpStatus.value(),
-        stagingVehicleScheduleFrameId,
-        targetVehicleScheduleFrameIds
-    )
+    companion object {
+        fun from(ex: MultipleTargetFramesFoundException) = MultipleTargetFramesFoundExtensions(
+            HttpStatus.CONFLICT.value(),
+            ex.stagingVehicleScheduleFrameId,
+            ex.targetVehicleScheduleFrameIds
+        )
+    }
 }
 
 data class TargetPriorityParsingExtensions(
@@ -67,5 +79,10 @@ data class TargetPriorityParsingExtensions(
     val targetPriority: Int
 ) : HasuraErrorExtensions {
 
-    constructor(httpStatus: HttpStatus, targetPriority: Int) : this(httpStatus.value(), targetPriority)
+    companion object {
+        fun from(ex: TargetPriorityParsingException) = TargetPriorityParsingExtensions(
+            HttpStatus.BAD_REQUEST.value(),
+            ex.targetPriority
+        )
+    }
 }

--- a/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesCombineApiTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesCombineApiTest.kt
@@ -74,7 +74,7 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                 MockMvcResultMatchers.content().json(
                     """
                     {
-                      "combinedIntoVehicleScheduleFrameIds": ${MAPPER.writeValueAsString(defaultTargetFrameIds)}
+                      "combinedIntoVehicleScheduleFrameIds": $defaultTargetFrameIds
                     }
                     """.trimIndent(),
                     true

--- a/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesCombineApiTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesCombineApiTest.kt
@@ -76,7 +76,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                     {
                       "combinedIntoVehicleScheduleFrameIds": ${MAPPER.writeValueAsString(defaultTargetFrameIds)}
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -106,7 +107,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                         "code": 409
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -152,7 +154,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                         "stagingVehicleScheduleFrameId": "$missingStagingFrameId"
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -185,7 +188,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                         "targetPriority": $invalidTargetPriority
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -217,7 +221,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                         "stagingVehicleScheduleFrameId": ${defaultStagingFrameIds[0]}
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -250,7 +255,8 @@ class TimetablesCombineApiTest(@Autowired val mockMvc: MockMvc) {
                         "targetVehicleScheduleFrameIds": $defaultTargetFrameIds
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 

--- a/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesReplaceApiTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesReplaceApiTest.kt
@@ -77,7 +77,7 @@ class TimetablesReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                 content().json(
                     """
                     {
-                      "replacedVehicleScheduleFrameIds": ${OBJECT_MAPPER.writeValueAsString(defaultReplacedFrameIds)}
+                      "replacedVehicleScheduleFrameIds": $defaultReplacedFrameIds
                     }
                     """.trimIndent(),
                     true

--- a/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesReplaceApiTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesReplaceApiTest.kt
@@ -79,7 +79,8 @@ class TimetablesReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                     {
                       "replacedVehicleScheduleFrameIds": ${OBJECT_MAPPER.writeValueAsString(defaultReplacedFrameIds)}
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -112,7 +113,8 @@ class TimetablesReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                         "code": 409
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -161,7 +163,8 @@ class TimetablesReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                         "stagingVehicleScheduleFrameId": "$missingStagingFrameId"
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -197,7 +200,8 @@ class TimetablesReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                         "targetPriority": $invalidTargetPriority
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 

--- a/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesToReplaceApiTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/api/TimetablesToReplaceApiTest.kt
@@ -78,7 +78,8 @@ class TimetablesToReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                     {
                       "toReplaceVehicleScheduleFrameIds": $defaultToReplaceIds
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
 
@@ -109,7 +110,8 @@ class TimetablesToReplaceApiTest(@Autowired val mockMvc: MockMvc) {
                         "targetPriority": $invalidTargetPriorityInput
                       }
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
+                    true
                 )
             )
         verify(exactly = 0) {


### PR DESCRIPTION
- Enable strict mode while verifying JSON content in responses in REST API tests.
- Remove unnecessary use of Jackson ObjectMapper in some test assertions.
- Do some REST API code refactoring as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-timetables-api/12)
<!-- Reviewable:end -->
