### PR TITLE
Change database user in application configuration

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -13,6 +13,16 @@ services:
       - jore4
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    environment:
+      SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
+      JORE4_DB_HOSTNAME: "jore4-testdb"
+    secrets:
+      - source: timetablesapi-jore4-db-database
+        target: /mnt/secrets-store/jore4-db-database
+      - source: timetablesapi-jore4-db-password
+        target: /mnt/secrets-store/jore4-db-password
+      - source: timetablesapi-jore4-db-username
+        target: /mnt/secrets-store/jore4-db-username
 
   jore4-hasura:
     # locking hasura image so that we can develop against a static graphql API

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -18,7 +18,7 @@ services:
     # locking hasura image so that we can develop against a static graphql API
     # Link to available jore4-hasura images in Docker Hub:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
-    image: "hsldevcom/jore4-hasura:hsl-main--20231011-bbd4c8750a5e09e115a8a1350ec9f6f10e43eb65"
+    image: "hsldevcom/jore4-hasura:hsl-main--20231019-667942672c4ff4f7493a49903f6ed2bbe35a7615"
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/profiles/dev/config.properties
+++ b/profiles/dev/config.properties
@@ -1,8 +1,8 @@
 # Datasource settings of the Jore 4 development database
 jore4.db.driver=org.postgresql.Driver
 jore4.db.url=jdbc:postgresql://localhost:6432/timetablesdb?stringtype=unspecified
-jore4.db.username=dbhasura
-jore4.db.password=hasurapassword
+jore4.db.username=dbtimetablesapi
+jore4.db.password=timetablesapipassword
 jore4.db.min.connections=0
 jore4.db.max.connections=5
 

--- a/script/build-jdbc-urls.sh
+++ b/script/build-jdbc-urls.sh
@@ -6,12 +6,6 @@ set -eu
 
 # if JORE4_DB_URL was not set, build it from parts
 if [ -z "${JORE4_DB_URL+x}" ]; then
-  export JORE4_DB_HOSTNAME=${JORE4_DB_HOSTNAME:-"jore4-testdb"}
   export JORE4_DB_PORT=${JORE4_DB_PORT:-"5432"}
-  export JORE4_DB_DATABASE=${JORE4_DB_DATABASE:-"timetablesdb"}
   export JORE4_DB_URL="jdbc:postgresql://${JORE4_DB_HOSTNAME}:${JORE4_DB_PORT}/${JORE4_DB_DATABASE}?stringtype=unspecified"
 fi
-
-# Set dev auth if it is not defined
-export JORE4_DB_USERNAME=${JORE4_DB_USERNAME:-"dbhasura"}
-export JORE4_DB_PASSWORD=${JORE4_DB_PASSWORD:-"hasurapassword"}

--- a/src/test/kotlin/fi/hsl/jore4/timetables/IntTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/IntTest.kt
@@ -1,0 +1,14 @@
+package fi.hsl.jore4.timetables
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * A custom annotation which configures integration tests which use the test database settings.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@SpringBootTest
+@ActiveProfiles("test")
+annotation class IntTest

--- a/src/test/kotlin/fi/hsl/jore4/timetables/config/DataInserterDatabaseProperties.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/config/DataInserterDatabaseProperties.kt
@@ -2,7 +2,7 @@ package fi.hsl.jore4.timetables.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(prefix = "dataInserter.db")
+@ConfigurationProperties(prefix = "data-inserter.db")
 data class DataInserterDatabaseProperties(
     val username: String,
     val password: String

--- a/src/test/kotlin/fi/hsl/jore4/timetables/service/CombineTimetablesServiceTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/service/CombineTimetablesServiceTest.kt
@@ -1,6 +1,7 @@
 package fi.hsl.jore4.timetables.service
 
 import fi.hsl.jore.jore4.jooq.vehicle_schedule.tables.pojos.VehicleScheduleFrame
+import fi.hsl.jore4.timetables.IntTest
 import fi.hsl.jore4.timetables.TimetablesDataset
 import fi.hsl.jore4.timetables.enumerated.TimetablesPriority
 import fi.hsl.jore4.timetables.extensions.deepClone
@@ -12,8 +13,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.util.UUID
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -21,8 +20,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@SpringBootTest
-@ActiveProfiles("test")
+@IntTest
 class CombineTimetablesServiceTest @Autowired constructor(
     val combineTimetablesService: CombineTimetablesService,
     var timetablesDataInserterRunner: TimetablesDataInserterRunner,

--- a/src/test/kotlin/fi/hsl/jore4/timetables/service/ReplaceTimetablesServiceTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/service/ReplaceTimetablesServiceTest.kt
@@ -1,19 +1,17 @@
 package fi.hsl.jore4.timetables.service
 
 import fi.hsl.jore.jore4.jooq.vehicle_schedule.tables.pojos.VehicleScheduleFrame
+import fi.hsl.jore4.timetables.IntTest
 import fi.hsl.jore4.timetables.TimetablesDataset
 import fi.hsl.jore4.timetables.enumerated.TimetablesPriority
 import fi.hsl.jore4.timetables.extensions.deepClone
 import fi.hsl.jore4.timetables.extensions.getNested
 import fi.hsl.jore4.timetables.repository.VehicleScheduleFrameRepository
-import mu.KotlinLogging
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.assertContains
@@ -21,10 +19,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
-private val LOGGER = KotlinLogging.logger {}
-
-@SpringBootTest
-@ActiveProfiles("test")
+@IntTest
 class ReplaceTimetablesServiceTest @Autowired constructor(
     val replaceTimetablesService: ReplaceTimetablesService,
     var timetablesDataInserterRunner: TimetablesDataInserterRunner,

--- a/src/test/kotlin/fi/hsl/jore4/timetables/service/TimetablesDataInserterRunner.kt
+++ b/src/test/kotlin/fi/hsl/jore4/timetables/service/TimetablesDataInserterRunner.kt
@@ -1,16 +1,13 @@
 package fi.hsl.jore4.timetables.service
 
-import fi.hsl.jore4.timetables.config.DatabaseProperties
 import fi.hsl.jore4.timetables.config.DataInserterDatabaseProperties
-import mu.KotlinLogging
+import fi.hsl.jore4.timetables.config.DatabaseProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Service
 import java.io.File
 import java.net.URI
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-
-private val LOGGER = KotlinLogging.logger {}
 
 @Service
 @EnableConfigurationProperties(DataInserterDatabaseProperties::class)

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,2 +1,2 @@
-dataInserter.db.username=dbhasura
-dataInserter.db.password=hasurapassword
+data-inserter.db.username=dbhasura
+data-inserter.db.password=hasurapassword


### PR DESCRIPTION
The change is done in order to spot possible database permission issues. Also, remove defaulting to Hasura user in Docker setup.

Continue to use the Hasura user for integration tests, as Data-Inserter needs permissions to execute `TRUNCATE` SQL commands to the database.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-timetables-api/14)
<!-- Reviewable:end -->
