### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/check-renovatebot-config.yml
+++ b/.github/workflows/check-renovatebot-config.yml
@@ -14,6 +14,6 @@ jobs:
           submodules: recursive
 
       - name: Validate
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
         with:
           config_file_path: .github/renovate.json5

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ jobs:
   push_to_registry:
     needs: run_java_tests
     name: Build & Push docker image to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   run_cypress_tests:
     name: Run cypress e2e tests from docker
+    # These must run on ubuntu 22.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/run-java-tests.yml
+++ b/.github/workflows/run-java-tests.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   run-tests:
     name: Run java tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -28,13 +28,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Run tests and try building a package
         run: |

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-docker-compose:
     name: verify docker-compose setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
* Run on Ubuntu 24.04 or 22.04 for tasks requiring e2e env
* Use actions/setup-java build-in cache
* Set suzuki-shunsuke/github-action-renovate-config-validator to use latest v1 release

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-timetables-api/29)
<!-- Reviewable:end -->
