### PR TITLE
Refactor downloading Docker Compose bundle

### DIFF
--- a/development.sh
+++ b/development.sh
@@ -21,10 +21,15 @@ instruct_and_exit() {
 }
 
 download_docker_bundle() {
-  # based on https://github.com/HSLdevcom/jore4-tools#download-docker-bundlesh
+  echo "Downloading the latest version of the JORE4 E2E Docker Compose bundle..."
 
-  echo "Downloading latest version of E2E docker-compose package..."
-  curl https://raw.githubusercontent.com/HSLdevcom/jore4-tools/main/docker/download-docker-bundle.sh | bash
+  # Download the JORE4 Docker Compose bundle as ZIP file.
+  curl -L -o jore4-docker-compose-bundle.zip https://github.com/HSLdevcom/jore4-docker-compose-bundle/archive/refs/heads/main.zip
+
+  # Extract only the contents of the `docker-compose` directory.
+  unzip jore4-docker-compose-bundle.zip "jore4-docker-compose-bundle-main/docker-compose/*" -d .
+  mv jore4-docker-compose-bundle-main/docker-compose/* ./docker
+  rm -rf jore4-docker-compose-bundle-main jore4-docker-compose-bundle.zip
 }
 
 start_all() {

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 services:
   # build and run the local image instead
   # note: it's currently expose on port 3009


### PR DESCRIPTION
Docker Compose bundle is now downloaded as a ZIP file from [jore4-docker-compose-bundle](https://github.com/HSLdevcom/jore4-docker-compose-bundle) repository instead of downloading the latest release from [jore4-tools](https://github.com/HSLdevcom/jore4-tools).